### PR TITLE
Fix lint warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,3 @@ require (
 	github.com/stretchr/testify v1.4.0
 	v.io v0.1.9
 )
-
-

--- a/markduplicates/duplicate_index.go
+++ b/markduplicates/duplicate_index.go
@@ -187,11 +187,11 @@ func (d *duplicateIndex) insertSingleton(r *sam.Record, fileIdx uint64) {
 
 	fivePosition := bam.UnclippedFivePrimePosition(r)
 	orientation := orientationByteSingle(bam.IsReversedRead(r))
-	var strand strand
+	var s strand
 	if d.opts.StrandSpecific {
-		strand = r1Strand(r)
+		s = r1Strand(r)
 	}
-	key := duplicateKey{r.Ref.ID(), fivePosition, -1, -1, orientation, strand}
+	key := duplicateKey{r.Ref.ID(), fivePosition, -1, -1, orientation, s}
 	d.entries[key] = append(d.entries[key], IndexedSingle{r, fileIdx})
 }
 
@@ -214,15 +214,15 @@ func (d *duplicateIndex) insertPair(a, b *sam.Record, aFileIdx, bFileIdx uint64)
 	}
 
 	// Update duplicate set.
-	var strand strand
+	var s strand
 	if d.opts.StrandSpecific {
-		strand = r1Strand(a)
+		s = r1Strand(a)
 	}
 	key := duplicateKey{
 		left.R.Ref.ID(), bam.UnclippedFivePrimePosition(left.R),
 		right.R.Ref.ID(), bam.UnclippedFivePrimePosition(right.R),
 		orientationBytePair(bam.IsReversedRead(left.R), bam.IsReversedRead(right.R)),
-		strand,
+		s,
 	}
 	d.entries[key] = append(d.entries[key], IndexedPair{left, right})
 }

--- a/markduplicates/mark_duplicates.go
+++ b/markduplicates/mark_duplicates.go
@@ -122,8 +122,6 @@ type maxAlignDistCheck struct {
 	clearExisting      bool
 	padding            int
 	maxAlignDist       int
-	maxX               int
-	maxY               int
 	globalMaxAlignDist *int
 	mutex              *sync.Mutex
 }


### PR DESCRIPTION
2/4 of these lint warnings of type (duplicate_index.go []: shadow: declaration of "strand" shadows declaration at line 23) seem invalid but this commit renames the variables anyway to remove them.